### PR TITLE
feat: Add last_login and date_joined fields to SuperUserSeeder

### DIFF
--- a/MyAppWeb/auth_app/seeders/super_user_seeder.py
+++ b/MyAppWeb/auth_app/seeders/super_user_seeder.py
@@ -1,5 +1,6 @@
 from jessilver_django_seed.seeders.BaseSeeder import BaseSeeder
 from django.contrib.auth import get_user_model
+from django.utils.timezone import now
 
 class SuperUserSeeder(BaseSeeder):
     @property
@@ -17,6 +18,8 @@ class SuperUserSeeder(BaseSeeder):
                 first_name='Admin',
                 last_name='User',
                 is_active=True,
+                last_login=now(),
+                date_joined=now()
             )
             self.succes(f'Super User created')
         else:


### PR DESCRIPTION
This pull request updates the `SuperUserSeeder` class in `MyAppWeb/auth_app/seeders/super_user_seeder.py` to include additional fields when creating a superuser. The changes ensure that the `last_login` and `date_joined` fields are set to the current timestamp during seeding.

Enhancements to superuser seeding:

* [`MyAppWeb/auth_app/seeders/super_user_seeder.py`](diffhunk://#diff-233722808a480d4dbd5ab6fd8b8f646af80153991f21dd47c8149c7d7422f1e5R3): Imported `now` from `django.utils.timezone` to use the current timestamp.
* [`MyAppWeb/auth_app/seeders/super_user_seeder.py`](diffhunk://#diff-233722808a480d4dbd5ab6fd8b8f646af80153991f21dd47c8149c7d7422f1e5R21-R22): Updated the `seed` method to set the `last_login` and `date_joined` fields to the current timestamp when creating a superuser.