### PR TITLE
feat: Add 'Mercados' link to navbar and remove unused left image from…

### DIFF
--- a/MyAppWeb/core/templates/navbar.html
+++ b/MyAppWeb/core/templates/navbar.html
@@ -202,6 +202,14 @@
                 Produtos
               </div>
             </a>
+            <a href="{% url 'register_market' %}" class="block p-4 text-center rounded-lg hover:bg-gray-100 group">
+              <svg aria-hidden="true" class="mx-auto mb-1 w-7 h-7 text-gray-400 group-hover:text-gray-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M10 2a4 4 0 00-4 4v1H5a1 1 0 00-.994.89l-1 9A1 1 0 004 18h12a1 1 0 00.994-1.11l-1-9A1 1 0 0015 7h-1V6a4 4 0 00-4-4zm2 5V6a2 2 0 10-4 0v1h4zm-6 3a1 1 0 112 0 1 1 0 01-2 0zm7-1a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"></path>
+              </svg>
+              <div class="text-sm text-gray-900">
+                Mercados
+              </div>
+            </a>
             {% comment %}
             <a href="#" class="block p-4 text-center rounded-lg hover:bg-gray-100 group">
               <svg aria-hidden="true" class="mx-auto mb-1 w-7 h-7 text-gray-400 group-hover:text-gray-500" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">

--- a/MyAppWeb/market/templates/market/create.html
+++ b/MyAppWeb/market/templates/market/create.html
@@ -12,7 +12,6 @@
 <div class="grid grid-cols-1 md:grid-cols-3 w-full gap-4 px-4 pt-20">
 
   <div class="hidden sm:block md:col-span-1 relative">
-    <img id="left_img" class="w-full h-auto max-h-[500px] object-contain" src="{% static 'src/core/img/Left_back.svg' %}" alt="">
     <div class="absolute top-0 left-0 flex flex-col justify-center gap-12 w-full pt-4">
       {% include "index/moto.html" %}
       {% include "index/carrinho.html" %}


### PR DESCRIPTION
This pull request introduces changes to the user interface by adding a new navigation link to the navbar and removing an unused image from the market creation page.

### UI Enhancements:

* [`MyAppWeb/core/templates/navbar.html`](diffhunk://#diff-4f133934c575dbe4d0463999fb92294c073dbe7bfefc9b0f5b49661ea0431baaR205-R212): Added a new navigation link labeled "Mercados" to the navbar. This includes an icon and text, linking to the `register_market` URL.

### Code Cleanup:

* [`MyAppWeb/market/templates/market/create.html`](diffhunk://#diff-419a5d6ce748641f46dce1c9b3473f7cccde1e2becfa25ed61b5525c15262d24L15): Removed an unused image (`Left_back.svg`) from the market creation page to simplify the layout.… create page