### PR TITLE
Feat/019/criacao das apis de separadores

### DIFF
--- a/MyAppWeb/users/seeders/separeter_user_seeder.py
+++ b/MyAppWeb/users/seeders/separeter_user_seeder.py
@@ -1,0 +1,28 @@
+from jessilver_django_seed.seeders.BaseSeeder import BaseSeeder
+from django.contrib.auth import get_user_model
+from django.utils.timezone import now
+
+class SeparaterUserSeeder(BaseSeeder):
+    @property
+    def seeder_name(self):
+        return 'SeparaterUserSeeder'
+
+    def seed(self):
+        from users.models import SeparaterUser
+        User = get_user_model()
+        if not User.objects.filter(email='separater@example.com').exists():
+            user = User.objects.create_user(
+                email='separater@example.com',
+                password='123456789',
+                is_active=True,
+                user_type='separater',
+            )
+            SeparaterUser.objects.create(
+                user=user,
+                first_name='Separador',
+                last_name='Teste',
+                cpf='36396715031'
+            )
+            self.succes('Separater User and SeparaterUser created')
+        else:
+            self.error('Separater User already exists')

--- a/MyAppWeb/users/serializers.py
+++ b/MyAppWeb/users/serializers.py
@@ -139,6 +139,27 @@ class SeparaterUserSerializer(serializers.ModelSerializer):
         model = SeparaterUser
         fields = ['user', 'first_name', 'last_name', 'cpf', 'address']
 
+    def update(self, instance, validated_data):
+        # Extrai os dados aninhados do usuário
+        user_data = validated_data.pop('user', None)
+
+        # Atualiza os campos de ClientUser
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+
+        # Atualiza os campos do User
+        if user_data:
+            user = instance.user
+            for attr, value in user_data.items():
+                if attr == 'password':
+                    user.set_password(value)
+                else:
+                    setattr(user, attr, value)
+            user.save()
+
+        return instance
+    
     def create(self, validated_data):
         user_data = validated_data.pop('user')
         address_data = validated_data.pop('address', None)

--- a/MyAppWeb/users/tests.py
+++ b/MyAppWeb/users/tests.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from django.utils.timezone import now
 from users.models import ClientUser, DeliveryUser, SupermarketUser, SeparaterUser
 from auth_app.models import User
-from django.urls import reverse
 from rest_framework import status
 
 from rest_framework.test import APITestCase

--- a/MyAppWeb/users/tests.py
+++ b/MyAppWeb/users/tests.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 from django.utils.timezone import now
 from users.models import ClientUser, DeliveryUser, SupermarketUser, SeparaterUser
 from auth_app.models import User
+from django.urls import reverse
+from rest_framework import status
 
 from rest_framework.test import APITestCase
 from rest_framework import status
@@ -51,7 +53,6 @@ class ClientUserModelTest(TestCase):
         self.client_user.save()
         self.assertEqual(ClientUser.objects.get(id=self.client_user.id).first_name, 'Maria')
 
-
 class DeliveryUserModelTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(email='delivery@example.com', password='123', groupName='delivery', last_login=now(), date_joined=now())
@@ -81,6 +82,66 @@ class SupermarketUserModelTest(TestCase):
         self.supermarket_user.fantasy_name = 'Mercado Top'
         self.supermarket_user.save()
         self.assertEqual(SupermarketUser.objects.get(id=self.supermarket_user.id).fantasy_name, 'Mercado Top')
+
+class SeparaterUserAPITests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email='separador1@example.com', password='123456789', is_active=True)
+        self.separater = SeparaterUser.objects.create(user=self.user, first_name='Separador', last_name="Teste", cpf='34567890123')
+    
+    def test_api_create_separater_user(self):
+        data = {
+            "user": {
+                "email": "separador2@example.com",
+                "password": "123456789",
+                "phone": "11987654321"
+                },
+            "first_name": "Separador",
+            "last_name": "Teste 2",
+            "cpf": "90425606066"
+        }
+        response = self.client.post('/users/separater-users/', data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(SeparaterUser.objects.count(), 2)
+        self.assertEqual(SeparaterUser.objects.get(cpf="90425606066").last_name, 'Teste 2')
+    
+    def test_api_delete_separater_user(self):
+        url = reverse('separater-user-delete', kwargs={'pk': self.separater.id})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(SeparaterUser.objects.count(), 0)
+    
+    def test_api_get_separater_user(self):
+        url = reverse('separater-user-get-one', kwargs={'pk': self.separater.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['last_name'], 'Teste')
+    
+    def test_api_put_update_separater_user(self):
+        url = reverse('separater-user-edit', kwargs={'pk': self.separater.id})
+        data = {
+            "user": {
+                "email": "separador1@example.com",
+                "password": "123456789",
+            },
+            "first_name": "Separador Atualizado",
+            "last_name": "Teste Atualizado",
+            "cpf": "34567890123",
+        }
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.separater.refresh_from_db()
+        self.assertEqual(self.separater.first_name, 'Separador Atualizado')
+        self.assertEqual(self.separater.last_name, 'Teste Atualizado')
+    
+    def test_api_patch_update_separater_user(self):
+        url = reverse('separater-user-edit', kwargs={'pk': self.separater.id})
+        data = {
+            "first_name": "Separador Parcial",
+        }
+        response = self.client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.separater.refresh_from_db()
+        self.assertEqual(self.separater.first_name, 'Separador Parcial')
 
 class SeparaterUserModelTest(TestCase):
     def setUp(self):

--- a/MyAppWeb/users/urls.py
+++ b/MyAppWeb/users/urls.py
@@ -4,6 +4,10 @@ from .views import *
 urlpatterns = [
     path('users/delivery-users/', DeliveryUserCreateView.as_view(), name='delivery-user-create'),
     path('users/separater-users/', SeparaterUserCreateView.as_view(), name='separater-user-create'),
+    path('users/separater-users/delete/<int:pk>', SeparaterUserDeleteView.as_view(), name='separater-user-delete'),
+    path('users/separater-users/edit/<int:pk>', SeparaterUserEditView.as_view(), name='separater-user-edit'),
+    path('users/separater-users/get/all', SeparaterUserListView.as_view(), name='separater-user-get-all'),
+    path('users/separater-users/get/<int:pk>', SeparaterUserGetView.as_view(), name='separater-user-get-one'),
 
     path('users/addresses/', AddressCreateView.as_view(), name='address-create'),
     path('users/addresses/delete/<int:pk>', AddressDeleteView.as_view(), name='address-delete'),

--- a/MyAppWeb/users/views.py
+++ b/MyAppWeb/users/views.py
@@ -131,6 +131,121 @@ class SeparaterUserCreateView(generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
+class SeparaterUserDeleteView(generics.DestroyAPIView):
+    queryset = SeparaterUser.objects.all()
+    serializer_class = SeparaterUserSerializer
+    lookup_field = 'pk'
+
+    @swagger_auto_schema(
+        operation_description="Deleta um usuário do tipo SeparaterUser, identificado pelo ID.",
+        responses={
+            204: openapi.Response("Usuário deletado com sucesso"),
+            404: openapi.Response("Usuário não encontrado")
+        },
+    )
+    def delete(self, request, *args, **kwargs):
+        return super().delete(request, *args, **kwargs)
+
+class SeparaterUserEditView(generics.UpdateAPIView):
+    queryset = SeparaterUser.objects.all()
+    serializer_class = SeparaterUserSerializer
+    lookup_field = 'pk'
+
+    @swagger_auto_schema(
+        operation_description="Atualiza os dados de um usuário do tipo SeparaterUser, identificado pelo ID.",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'user': openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        'email': openapi.Schema(type=openapi.TYPE_STRING, description="Email do usuário"),
+                        'password': openapi.Schema(type=openapi.TYPE_STRING, description="Senha do usuário")
+                    }
+                ),
+                'first_name': openapi.Schema(type=openapi.TYPE_STRING, description="Primeiro nome do separador"),
+                'last_name': openapi.Schema(type=openapi.TYPE_STRING, description="Sobrenome do separador (opcional)"),
+                'cpf': openapi.Schema(type=openapi.TYPE_STRING, description="CPF do separador (11 dígitos, único)"),
+            },
+            required=['user', 'first_name', 'cpf'],
+                    example={
+                "user": {
+                    "email": "separador1@example.com",
+                    "password": "123456789"
+                },
+                "first_name": "Carlos",
+                "last_name": "Alberto",
+                "cpf": "12345678901"
+            }
+        ),
+            responses={
+                200: DeliveryUserSerializer,
+                400: openapi.Response("Erro na atualização. Verifique os dados enviados."),
+                404: openapi.Response("Entregador não encontrado.")
+            }
+    )
+
+    def put(self, request, *args, **kwargs):
+        return super().put(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        operation_description="Atualiza parcialmente os dados de um SeparaterUser, identificado pelo ID.",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'user': openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        'email': openapi.Schema(type=openapi.TYPE_STRING, description="Email do usuário"),
+                        'password': openapi.Schema(type=openapi.TYPE_STRING, description="Senha do usuário")
+                    }
+                ),
+                'first_name': openapi.Schema(type=openapi.TYPE_STRING, description="Primeiro nome do separador"),
+                'last_name': openapi.Schema(type=openapi.TYPE_STRING, description="Sobrenome do separador (opcional)"),
+                'cpf': openapi.Schema(type=openapi.TYPE_STRING, description="CPF do separador (11 dígitos, único)"),
+            },
+            required=[],
+            example={
+                "first_name": "Carlos",
+            }
+        ),
+            responses={
+                200: DeliveryUserSerializer,
+                400: openapi.Response("Erro na atualização. Verifique os dados enviados."),
+                404: openapi.Response("Separador não encontrado.")
+            }
+        )
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
+class SeparaterUserGetView(generics.RetrieveAPIView):
+    queryset = SeparaterUser.objects.all()
+    serializer_class = SeparaterUserSerializer
+    lookup_field = "pk"
+
+    @swagger_auto_schema(
+        operation_description="Obtém os detalhes de um separador específico, identificado pelo ID.",
+        responses={
+            200: SeparaterUserSerializer,
+            404: openapi.Response("Usuário não encontrado.")
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+    
+class SeparaterUserListView(generics.ListAPIView):
+    queryset = SeparaterUser.objects.all()
+    serializer_class = SeparaterUserSerializer
+
+    @swagger_auto_schema(
+        operation_description="Lista todos os usuários cadastrados do tipo separador (SeparaterUser).",
+        responses={
+            200: SeparaterUserSerializer(many=True),
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
 class AddressCreateView(generics.CreateAPIView):
     queryset = Address.objects.all()
     serializer_class = AddressSerializer


### PR DESCRIPTION
This pull request introduces functionality for managing `SeparaterUser` entities in the application, including seeding, serialization, API endpoints, and testing. The most important changes include adding a new seeder for `SeparaterUser`, extending the serializer to handle updates, implementing comprehensive API views for CRUD operations, updating the URL routing, and adding corresponding API tests.

### New functionality for `SeparaterUser` management:

#### Seeder:
* Added `SeparaterUserSeeder` to seed a default `SeparaterUser` entity if it does not already exist. (`MyAppWeb/users/seeders/separeter_user_seeder.py`)

#### Serialization:
* Extended `SeparaterUserSerializer` to support nested updates for `User` fields, including handling password changes. (`MyAppWeb/users/serializers.py`)

#### API Views:
* Added `SeparaterUserDeleteView`, `SeparaterUserEditView`, `SeparaterUserGetView`, and `SeparaterUserListView` for CRUD operations on `SeparaterUser` entities. Swagger documentation was included for each view. (`MyAppWeb/users/views.py`)

#### URL Routing:
* Updated `urls.py` to include routes for the new API views (`delete`, `edit`, `get one`, `get all`) for `SeparaterUser`. (`MyAppWeb/users/urls.py`)

#### Testing:
* Added API tests for `SeparaterUser` endpoints, including `create`, `delete`, `get`, `put`, and `patch` operations. (`MyAppWeb/users/tests.py`)